### PR TITLE
Handle inference-only datasets

### DIFF
--- a/scripts/train_mlp.py
+++ b/scripts/train_mlp.py
@@ -503,6 +503,11 @@ def train_model(embeddings_dir=None, output_dir=None, epochs=100, lr=0.001, batc
         
         if not output_dir:
             output_dir = determine_output_dir(session_dir=session_dir)
+
+        train_path = Path(embeddings_dir) / "X_train.npy"
+        val_path = Path(embeddings_dir) / "X_val.npy"
+        if not train_path.exists() or not val_path.exists():
+            raise ValueError("Training data not found. Ensure preprocessing created valid train/val files.")
         
         output_dir = Path(output_dir)
         models_dir = output_dir / "models"

--- a/scripts/train_svm.py
+++ b/scripts/train_svm.py
@@ -810,7 +810,12 @@ def train_svm_pipeline(embeddings_dir=None, output_dir=None, fast_mode=False, gr
         
         if not output_dir:
             output_dir = determine_output_dir(session_dir=session_dir)
-        
+
+        train_path = Path(embeddings_dir) / "X_train.npy"
+        val_path = Path(embeddings_dir) / "X_val.npy"
+        if not train_path.exists() or not val_path.exists():
+            raise ValueError("Training data not found. Ensure preprocessing created valid train/val files.")
+
         # Create output directory structure
         output_dir = Path(output_dir)
         


### PR DESCRIPTION
## Summary
- preprocess: detect missing labels and skip training when necessary
- enhanced_utils_unified: skip training steps in inference-only mode
- train_mlp & train_svm: validate that train/val embeddings exist before training

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868033ed12c83259b186e8b57f6721b