### PR TITLE
Improve GUI pipeline and encoding handling

### DIFF
--- a/gui_data_dashboard.py
+++ b/gui_data_dashboard.py
@@ -5,8 +5,9 @@ Simplified Streamlit dashboard for uploading a CSV and running the analysis pipe
 
 import streamlit as st
 import pandas as pd
-import tempfile
+import json
 from pathlib import Path
+from datetime import datetime
 
 from scripts.pipeline_runner import run_complete_csv_analysis
 
@@ -14,15 +15,25 @@ st.set_page_config(page_title="Sentiment Analysis", layout="wide")
 
 st.title("Upload & Analyze")
 
-uploaded = st.file_uploader("Upload CSV file", type=["csv"])
+uploaded = st.file_uploader("Upload & Analyze", type=["csv"])
 
-df = None
+if "analysis_done" not in st.session_state:
+    st.session_state.analysis_done = False
 
-if uploaded:
+if uploaded and not st.session_state.analysis_done:
+    raw_dir = Path("data") / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    saved_csv = raw_dir / f"upload_{timestamp}.csv"
+    with open(saved_csv, "wb") as f:
+        f.write(uploaded.getbuffer())
+
     try:
-        df = pd.read_csv(uploaded, encoding="utf-8", engine="python")
+        df = pd.read_csv(saved_csv, encoding="utf-8")
+    except UnicodeDecodeError:
+        df = pd.read_csv(saved_csv, encoding="latin-1")
     except Exception:
-        df = pd.read_csv(uploaded, encoding="latin-1", engine="python")
+        df = pd.read_csv(saved_csv, encoding="utf-8", errors="replace")
 
     df.columns = df.columns.str.strip().str.lower()
     df = df.rename(columns=lambda c: (
@@ -32,28 +43,43 @@ if uploaded:
     if "label" in df.columns:
         df["label"] = df["label"].replace({"positive": 1, "negative": 0, "pos": 1, "neg": 0})
 
-    st.subheader("Data Preview")
-    st.dataframe(df.head(200), use_container_width=True, height=400)
+    st.session_state.uploaded_df = df
 
-if uploaded and st.button("Start Analysis"):
-    with st.spinner("Running pipeline..."):
-        tmp_dir = tempfile.TemporaryDirectory()
-        tmp_csv = Path(tmp_dir.name) / "data.csv"
-        df.to_csv(tmp_csv, index=False)
-        results = run_complete_csv_analysis(str(tmp_csv))
-        tmp_dir.cleanup()
+    with st.spinner("Running full pipeline..."):
+        results = run_complete_csv_analysis(str(saved_csv))
 
-    if results.get("success"):
+    st.session_state.results = results
+    st.session_state.analysis_done = True
+
+if st.session_state.get("analysis_done"):
+    df = st.session_state.get("uploaded_df")
+    results = st.session_state.get("results")
+
+    if df is not None:
+        st.subheader("Data Preview")
+        st.dataframe(df.head(200), use_container_width=True, height=400)
+
+    if results and results.get("success"):
         st.success("Analysis completed!")
-        summary = results["final_results"].get("summary", {})
-        insights = results["final_results"].get("insights", [])
+        final = results.get("final_results", {})
+        session_dir = final.get("session_directory")
+        summary = final.get("summary", {})
+        insights = final.get("insights", [])
 
-        if "label" in df.columns:
-            st.subheader("Label Distribution")
-            st.bar_chart(df["label"].value_counts())
+        if session_dir:
+            plots_dir = Path(session_dir) / "plots"
+            reports_dir = Path(session_dir) / "reports"
 
-        st.subheader("Text Length Distribution")
-        st.bar_chart(df["text"].astype(str).str.len())
+            if plots_dir.exists():
+                for img in sorted(plots_dir.glob("*.png")):
+                    st.image(str(img))
+
+            report_json = reports_dir / "evaluation_report.json"
+            if report_json.exists():
+                st.subheader("Evaluation Report")
+                with open(report_json, "r", encoding="utf-8") as f:
+                    report_data = json.load(f)
+                st.json(report_data)
 
         st.subheader("Summary Statistics")
         st.json(summary)
@@ -63,9 +89,9 @@ if uploaded and st.button("Start Analysis"):
             for ins in insights:
                 st.write(f"- {ins}")
 
-        zip_path = results["final_results"].get("zip_path")
+        zip_path = final.get("zip_path")
         if zip_path and Path(zip_path).exists():
             with open(zip_path, "rb") as f:
-                st.download_button("\U0001F4E5 Download Complete Report", f, "report_analysis.zip")
+                st.download_button("\U0001F4E5 Download Full Report", f, "report_analysis.zip")
     else:
         st.error(f"Pipeline failed: {results.get('error', 'unknown error')}")

--- a/main.py
+++ b/main.py
@@ -388,7 +388,13 @@ def launch_streamlit_app(gui_path: Path, project_root: Path) -> int:
         
         try:
             # Run Streamlit
-            result = subprocess.run(cmd, env=env)
+            result = subprocess.run(
+                cmd,
+                env=env,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
             return result.returncode
         finally:
             # Restore original directory
@@ -430,7 +436,14 @@ def setup_environment(project_root: Path) -> bool:
             print("\n📦 Installing dependencies...")
             try:
                 cmd = [sys.executable, "-m", "pip", "install", "-r", str(req_file)]
-                result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+                result = subprocess.run(
+                    cmd,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                )
                 print("✅ Dependencies installed successfully!")
                 logger.info("Dependencies installed successfully")
                 return True
@@ -488,6 +501,8 @@ def run_script_step(script_name: str, args: List[str], project_root: Path,
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=1800,  # 30 minutes timeout
             cwd=project_root
         )

--- a/scripts/embed_dataset.py
+++ b/scripts/embed_dataset.py
@@ -72,8 +72,10 @@ def load_csv_robust(path):
     """Load CSV with fallback encodings and normalized headers."""
     try:
         df = pd.read_csv(path, encoding="utf-8", engine="python")
-    except Exception:
+    except UnicodeDecodeError:
         df = pd.read_csv(path, encoding="latin-1", engine="python")
+    except Exception:
+        df = pd.read_csv(path, encoding="utf-8", errors="replace", engine="python")
 
     df.columns = df.columns.str.strip().str.lower()
     df = df.rename(columns=lambda c: (

--- a/scripts/enhanced_utils_unified.py
+++ b/scripts/enhanced_utils_unified.py
@@ -39,6 +39,8 @@ def run_subprocess_with_timeout(command: List[str], timeout: int = 300, cwd: Opt
             command,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             cwd=cwd,
             check=False

--- a/scripts/pipeline_runner.py
+++ b/scripts/pipeline_runner.py
@@ -52,8 +52,10 @@ def load_csv_robust(path):
     """Load CSV with fallback encodings and normalized headers."""
     try:
         df = pd.read_csv(path, encoding="utf-8", engine="python")
-    except Exception:
+    except UnicodeDecodeError:
         df = pd.read_csv(path, encoding="latin-1", engine="python")
+    except Exception:
+        df = pd.read_csv(path, encoding="utf-8", errors="replace", engine="python")
 
     df.columns = df.columns.str.strip().str.lower()
     df = df.rename(columns=lambda c: (
@@ -283,6 +285,8 @@ class PipelineRunner:
                 cmd,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
                 cwd=self.project_root
             )

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -35,8 +35,10 @@ def load_csv_robust(path):
     """Load CSV with fallback encodings and normalized headers."""
     try:
         df = pd.read_csv(path, encoding="utf-8", engine="python")
-    except Exception:
+    except UnicodeDecodeError:
         df = pd.read_csv(path, encoding="latin-1", engine="python")
+    except Exception:
+        df = pd.read_csv(path, encoding="utf-8", errors="replace", engine="python")
 
     df.columns = df.columns.str.strip().str.lower()
     df = df.rename(columns=lambda c: (


### PR DESCRIPTION
## Summary
- streamline Streamlit dashboard into a single upload-and-run flow
- save uploaded CSV to `data/raw` and execute complete pipeline automatically
- display analysis artifacts and offer a full report download
- load CSV files with fallback encodings in preprocessing and embedding
- run subprocesses with explicit UTF‑8 handling

## Testing
- `python -m py_compile main.py gui_data_dashboard.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68694794b28c832588146ea2b1d277d7